### PR TITLE
Change to logging, add 'Rpacks'

### DIFF
--- a/aRchive.py
+++ b/aRchive.py
@@ -192,10 +192,9 @@ def archive_local_repository(bioc_dir, archive_dir):
     rpacks = [directory for directory in os.listdir(rpack_dir) if not directory.startswith('.')]
     log.debug(' '.join(rpacks))
 
-    rpacks = ('SPIA', )
-
+    # TODO : rpacks[392:398] yaml tab problem test
+    rpacks = rpacks[392:398]
     for index, bioc_pack in enumerate(rpacks):
-        # TODO : rpacks[392:398] yaml tab problem test
         # Make Versions for EACH R package
         try:
             log.info("Archiving %s" % bioc_pack)


### PR DESCRIPTION
I'm wondering if this code ever worked, or if I broke things horribly with my pythonic PRs...
Going back to a860fb477f3778b0234583803d6f2e7bdff2bed3 even then, the `rpacks` variable contains `['Rpacks']` which is wrong, it should contain the folders inside of `bioc_dir/Rpacks/`.
- I've hardcoded in the `Rpacks` folder that's the top level folder, inside `bioc_dir` that's provided by the end user. 
  https://github.com/bioarchive/aRchive_source_code/compare/master...erasche:cwd?expand=1#diff-f63295d95262a1045c3464980e58d039R191
- switched to an enumerate for cleaner checking of when it's time to run `cleanup()`
- removed a `chdir` since that's a bit uglier than passing `cwd=path` to a subprocess command (harder for the developer to track what the expected result of a command should be)
