### PR TITLE
Switch to trunk and output dependency information

### DIFF
--- a/aRchive.py
+++ b/aRchive.py
@@ -86,15 +86,12 @@ def checkout(cwd, revision=None):
     if revision is not None:
         log.debug("Updating to rev %s" % revision)
         try:
-            log.debug("[A] {0} exists? {1}".format(cwd, os.path.exists(cwd)))
-            log.debug("cmd: {0}".format(["svn", "update", "-r", revision]))
             subprocess.check_call(["svn", "update", "-r", revision], cwd=cwd)
-            log.debug("[B] {0} exists? {1}".format(cwd, os.path.exists(cwd)))
         except Exception, e:
             log.warning("Exception checking output of svn checkout version: %s" % e)
     else:
         log.debug("Updating to latest rev")
-        subprocess.check_output(["svn", "update"], cwd=cwd)
+        subprocess.check_call(["svn", "update"], cwd=cwd)
 
 
 def cleanup(path):
@@ -146,14 +143,11 @@ def archive_package_versions(bioc_pack, archive_dir):
     # Loop through the revert IDs to find new versions
     for rev_id in revert_ids:
         log.debug("\n\nProcessing version ID: %s" % rev_id)
-        log.debug("[1] {0} exists? {1}".format(bioc_pack, os.path.exists(bioc_pack)))
         # Update repository to previous revert ID
         checkout(bioc_pack, revision=rev_id)
-        log.debug("[2] {0} exists? {1}".format(bioc_pack, os.path.exists(bioc_pack)))
         # Grab current version (or None if folder doesn't exist,
         # in which case we'll finish the loop)
         curr_version = get_package_version(bioc_pack)
-        log.debug("[3] {0} exists? {1}".format(bioc_pack, os.path.exists(bioc_pack)))
         if curr_version is not None:
             log.debug("Bioc_pack %s version of %s" % (curr_version, bioc_pack))
             # Create new directory with version number as "-version" extension
@@ -162,7 +156,6 @@ def archive_package_versions(bioc_pack, archive_dir):
             out_tarfile = "%s_%s.tar.gz" % (bioc_pack_name, curr_version)
             dest_tar_file = os.path.join(output_directory, out_tarfile)
 
-            log.debug("[4] {0} exists? {1}".format(bioc_pack, os.path.exists(bioc_pack)))
             log.info("\n output_directory: %s \n out_tarfile: %s \n dest_tar_file: %s" % (
                 output_directory, out_tarfile, dest_tar_file))
 

--- a/aRchive.py
+++ b/aRchive.py
@@ -50,7 +50,7 @@ def checkout_main_biocondutor_repository(path):
     else:
         subprocess.check_call(['svn', 'co', '--username', 'readonly',
                                '--password', 'readonly',
-                               'https://hedgehog.fhcrc.org/bioconductor/branches/RELEASE_3_0/madman/Rpacks/'])
+                               'https://hedgehog.fhcrc.org/bioconductor/trunk/madman/Rpacks/'])
     return "Bioconductor Release version repository updated"
 
 

--- a/aRchive.py
+++ b/aRchive.py
@@ -44,13 +44,14 @@ def checkout_main_biocondutor_repository(path):
     if not os.path.exists(path):
         os.mkdir(path)
 
-    os.chdir(path)
-    if os.path.isdir(".svn"):
-        subprocess.check_call(['svn', 'update'])
+    if os.path.isdir(os.path.join(path, ".svn")):
+        subprocess.check_call(['svn', 'update'], cwd=path)
     else:
         subprocess.check_call(['svn', 'co', '--username', 'readonly',
                                '--password', 'readonly',
-                               'https://hedgehog.fhcrc.org/bioconductor/trunk/madman/Rpacks/'])
+                               'https://hedgehog.fhcrc.org/bioconductor/trunk/madman/Rpacks/'],
+                              cwd=path
+                              )
     return "Bioconductor Release version repository updated"
 
 
@@ -63,7 +64,7 @@ def get_package_version(bioc_pack):
     """
     try:
         desc_file = os.path.join(bioc_pack, 'DESCRIPTION')
-        with open(os.path.join(bioc_pack, 'DESCRIPTION'), 'r') as handle:
+        with open(desc_file, 'r') as handle:
             # Hack to prevent DESCRIPTION files from failing to load,
             # because of yaml parsing.
             info = str([line[8:].strip() for i, line in enumerate(handle) if re.match("^Version: [0-9]", line)][0])

--- a/aRchive.py
+++ b/aRchive.py
@@ -234,7 +234,7 @@ def main():
     # Make the directory which user specifies to build the archive.
     if not os.path.exists(ARCHIVE_DIR):
         os.mkdir(ARCHIVE_DIR)
-    archive_local_repository(os.path.join(BIOCONDUCTOR_DIR,'Rpacks'), ARCHIVE_DIR)
+    archive_local_repository(os.path.join(BIOCONDUCTOR_DIR, 'Rpacks'), ARCHIVE_DIR)
 
 
 if __name__ == "__main__":

--- a/aRchive.py
+++ b/aRchive.py
@@ -55,6 +55,43 @@ def checkout_main_biocondutor_repository(path):
     return "Bioconductor Release version repository updated"
 
 
+def get_package_dependencies(bioc_pack):
+    """
+    Get the dependencies of the BioConductor package by parsing the
+    "DESCRIPTION" file
+
+    Args:
+      bioc_pack (str): Name of the BioConductor package
+    """
+    try:
+        desc_file = os.path.join(bioc_pack, 'DESCRIPTION')
+        with open(desc_file, 'r') as handle:
+            # Deps string
+            deps = ''
+            # Inside dependencies string
+            in_deps = False
+            for line in handle:
+                # If deps are starting
+                if line.startswith('Depends:') or line.startswith('Imports:'):
+                    in_deps = True
+                    deps += line.replace('Depends:', '').replace('Imports:', '').strip()
+                else:
+                    # If deps runs over multiple lines
+                    if in_deps:
+                        # If it starts with a space, then we're on a continuation
+                        # of the dependencies
+                        if line.startswith(' '):
+                            deps += line.strip()
+                        else:
+                            # If it starts with anything other than a space, then
+                            # we're no longer in the dependencies.
+                            in_deps = False
+        return [x.strip() for x in deps.split(',')]
+    except Exception, e:
+        log.warn("Could not obtain a version number for %s: %s" % (bioc_pack, e))
+        return None
+
+
 def get_package_version(bioc_pack):
     """
     Get the version of the BioConductor package by parsing the "DESCRIPTION"
@@ -140,6 +177,10 @@ def archive_package_versions(bioc_pack, archive_dir):
     latest_version = get_package_version(bioc_pack)
     log.info("Latest Version: %s" % latest_version)
 
+    bioc_pack_name = os.path.split(bioc_pack)[-1]
+    version_list_path = os.path.join(archive_dir, bioc_pack_name + '_versions_full.txt')
+
+    dependency_data = []
     # Loop through the revert IDs to find new versions
     for rev_id in revert_ids:
         log.debug("\n\nProcessing version ID: %s" % rev_id)
@@ -151,20 +192,26 @@ def archive_package_versions(bioc_pack, archive_dir):
         if curr_version is not None:
             log.debug("Bioc_pack %s version of %s" % (curr_version, bioc_pack))
             # Create new directory with version number as "-version" extension
-            bioc_pack_name = os.path.split(bioc_pack)[-1]
-            output_directory = os.path.join(archive_dir)
             out_tarfile = "%s_%s.tar.gz" % (bioc_pack_name, curr_version)
-            dest_tar_file = os.path.join(output_directory, out_tarfile)
+            dest_tar_file = os.path.join(archive_dir, out_tarfile)
 
             log.info("\n output_directory: %s \n out_tarfile: %s \n dest_tar_file: %s" % (
-                output_directory, out_tarfile, dest_tar_file))
+                archive_dir, out_tarfile, dest_tar_file))
+
+            if curr_version not in dependency_data:
+                deps = get_package_dependencies(bioc_pack)
+                dependency_data.append((
+                    int(rev_id[1:]),
+                    curr_version,
+                    deps
+                ))
 
             if not os.path.exists(dest_tar_file):
                 # SAVE THE CURRENT VERSION HERE
                 # Tar the directory
                 log.info('adding contents of bioc_pack %s to tarfile %s' % (bioc_pack, out_tarfile))
                 make_tarfile(out_tarfile, bioc_pack)
-                dest = os.path.join(output_directory, out_tarfile)
+                dest = os.path.join(archive_dir, out_tarfile)
                 log.info('Moving %s to %s' % (out_tarfile, dest))
                 shutil.move(out_tarfile, dest)
                 # Print contents and test
@@ -174,6 +221,18 @@ def archive_package_versions(bioc_pack, archive_dir):
         else:
             log.warn("No current version. Skipped everything! There is an error you are not catching")
             break
+    # Dump version info
+    dependency_data = dependency_data[::-1]
+    with open(version_list_path, 'w') as handle:
+        for version_idx in range(len(dependency_data) - 1):
+            from_version = dependency_data[version_idx]
+            to_version = dependency_data[version_idx + 0]
+
+            # (46412, '1.17.0', ['Biobase', 'graphics', 'grDevices', 'methods', 'multtest', 'stats', 'tcltk', 'utils'])
+            for specific_idx in range(from_version[0], to_version[0]):
+                handle.write('%s\t%s\t%s\n' % (specific_idx, from_version[1],
+                                               ','.join(from_version[2])))
+
     # Return to most recent update
     checkout(bioc_pack)
 
@@ -189,7 +248,6 @@ def archive_local_repository(bioc_dir, archive_dir):
     """
     # Get all bioconductor packages
     rpacks = [directory for directory in os.listdir(bioc_dir) if not directory.startswith('.')]
-    # log.debug(' '.join(rpacks))
 
     rpacks = rpacks[1:3]
     for index, package_name in enumerate(rpacks):

--- a/reduce_versions.py
+++ b/reduce_versions.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+import os
+import argparse
+
+
+def _important_revisions(dependency_file):
+    old_version = None
+    for line in dependency_file:
+        # 18438	1.1.2	Biobase,multtest
+        (rev, version, deps) = line.strip().split('\t')
+        if version != old_version:
+            old_version = version
+            yield (rev, version, deps.split(','))
+
+
+def get_version_at_rev(package, revision, archive_dir=None):
+    try:
+        with open(os.path.join(archive_dir, package + '_versions_full.txt'), 'r') as handle:
+            for line in handle:
+                if line.startswith(revision + '\t'):
+                    return '\t'.join((
+                        package,
+                        line.strip().split('\t')[1],
+                        '%s_%s_dependencies.txt' % (package, line.strip().split('\t')[1]),
+                        '%s_%s.tar.gz' % (package, line.strip().split('\t')[1])
+                    ))
+    except Exception:
+        return "# Could not find %s at r%s" % (package, revision)
+
+
+def main(dependency_file):
+    package_file = os.path.basename(dependency_file.name).replace('_versions_full.txt', '')
+    package_dir = os.path.dirname(dependency_file.name)
+    for (rev, version, deps) in _important_revisions(dependency_file):
+        version_deps_file = os.path.join(package_dir, '%s_%s_dependencies.txt' % (package_file, version))
+
+        versioned_deps = [get_version_at_rev(x, rev, archive_dir=package_dir)
+                          for x in deps]
+        with open(version_deps_file, 'w') as output:
+            output.write('\n'.join(versioned_deps))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser('Generate easy to consume dependencies')
+    parser.add_argument('dependency_file', type=file,
+                        help='PACKAGE_versions_full.txt file')
+    args = parser.parse_args()
+
+    main(**vars(args))


### PR DESCRIPTION
@nitesh1989 I think this is what was causing our issue of missing old revisions. This also explains why you didn't need the `Rpacks` folder whereas I did and we had all sorts of mixups there.
